### PR TITLE
chain get_currencybalance/stats: rename code to contract

### DIFF
--- a/src/api/v1/chain.json
+++ b/src/api/v1/chain.json
@@ -1,7 +1,7 @@
 {
   "get_currency_balance": {
     "params": {
-      "code": "name",
+      "contract": "name",
       "account": "name",
       "symbol": "optional<string>"
     },

--- a/src/api/v1/chain.json
+++ b/src/api/v1/chain.json
@@ -9,7 +9,7 @@
   },
   "get_currency_stats": {
     "params": {
-      "code": "name",
+      "contract": "name",
       "symbol": "string"
     },
     "results": {


### PR DESCRIPTION
for parity with cleos argument verbiage

```sh
$ cleos get currency balance
Retrieve the balance of an account for a given currency
Usage: /opt/eosio/bin/cleos get currency balance contract account [symbol]

Positionals:
  contract TEXT               The contract that operates the currency
  account TEXT                The account to query balances for
  symbol TEXT                 The symbol for the currency if the contract operates multiple currencies

$ cleos get currency stats
Retrieve the stats of for a given currency
Usage: /opt/eosio/bin/cleos get currency stats contract symbol

Positionals:
  contract TEXT               The contract that operates the currency
  symbol TEXT                 The symbol for the currency if the contract operates multiple currencies
```